### PR TITLE
Machine can be limited to exec a number of lines

### DIFF
--- a/src/lines.js
+++ b/src/lines.js
@@ -1,7 +1,9 @@
+const MaxInstructionsExceededException = require('./maxInstructionsExceededException.js');
 const ProgramCounter = require('./programCounter.js');
 
 class Lines {
-  constructor() {
+  constructor(maxLinesToExecute) {
+    this.maxLinesToExecute = maxLinesToExecute;
     this.lines = [];
     this.fnTable = {};
   }
@@ -16,9 +18,14 @@ class Lines {
     let state = { regs, flags, halt: false };
     let lineNumbers = this.lines.map(l => l.getLineNumber());
     let programCounter = new ProgramCounter(lineNumbers, this.fnTable);
+    let numberOfLinesExecuted = 0;
     let executor = () => {
       let line = this.lines[programCounter.getCurrentLineIndex()];
       state = line.execute(state.regs, state.flags, stack, programCounter);
+      numberOfLinesExecuted++;
+      if (numberOfLinesExecuted > this.maxLinesToExecute) {
+        throw new MaxInstructionsExceededException(this.maxLinesToExecute);
+      }
       state.nextLine = programCounter.getNextLineNumber();
       programCounter.update();
       cb(state);

--- a/src/machine.js
+++ b/src/machine.js
@@ -4,9 +4,10 @@ const Stack = require('./stack.js');
 const Lines = require('./lines.js');
 
 class Machine {
-  constructor() {
-    this.lines = new Lines();
+  constructor(maxLinesToExecute = 100) {
+    this.lines = new Lines(maxLinesToExecute);
     this.stack = new Stack();
+    this.maxLinesToExecute = maxLinesToExecute;
     this._reset();
   }
 
@@ -27,12 +28,13 @@ class Machine {
   }
 
   load(program) {
-    this.lines = new Lines();
     let instructions = program.split(/\n/);
     instructions.forEach((instruction, index) => {
       let line;
       try {
-        let { lineNumber, command, args, nonExecutableLine } = parse(instruction);
+        let { lineNumber, command, args, nonExecutableLine } = parse(
+          instruction
+        );
         if (nonExecutableLine) return;
         line = Line.create(lineNumber, command, args, index + 1, instruction);
       } catch (e) {

--- a/src/maxInstructionsExceededException.js
+++ b/src/maxInstructionsExceededException.js
@@ -1,0 +1,8 @@
+class MaxInstructionsExceededException extends Error {
+  constructor(maxLinesToExecute) {
+    super();
+    this.maxLinesToExecute = maxLinesToExecute;
+  }
+}
+
+module.exports = MaxInstructionsExceededException;

--- a/test/testMachine.js
+++ b/test/testMachine.js
@@ -17,13 +17,19 @@ describe('Machine loading', function() {
     const program = ['10 STAR'];
     assert.throws(() => machine.load(stitch(program)));
   });
-  
-  it('should throw an exception when there is a parse error in the arguments',() => {
+
+  it('should throw an exception when there is a parse error in the arguments', () => {
     const machine = new Machine();
     const missingArgumentProg = ['10 MOV A,'];
     const missingQuoteProg = ['10 PRN "HELLO'];
-    assert.throws(() => machine.load(stitch(missingArgumentProg)), InvalidInstructionException);
-    assert.throws(() => machine.load(stitch(missingQuoteProg)), InvalidInstructionException);
+    assert.throws(
+      () => machine.load(stitch(missingArgumentProg)),
+      InvalidInstructionException
+    );
+    assert.throws(
+      () => machine.load(stitch(missingQuoteProg)),
+      InvalidInstructionException
+    );
   });
 
   it('should ignore empty lines', function() {
@@ -690,5 +696,14 @@ describe('Machine with functions', () => {
     machine.load(stitch(program));
     machine.execute();
     assert.deepEqual({ A: 30, B: 0, C: 0, D: 0 }, machine.getRegs());
+  });
+});
+
+describe('Machine with infinite loops', () => {
+  it('should throw an exception when the machine executes more than 10 lines', () => {
+    const machine = new Machine(10);
+    const program = ['10 START', '20 JMP 10', '30 STOP'];
+    machine.load(stitch(program));
+    assert.throws(() => machine.execute());
   });
 });


### PR DESCRIPTION
The machine now takes an optional constructor argument(default 100)
that indicates how many lines the machine will execute before giving up
and raising an exception.

This is useful to trap potential infinite loop situations.